### PR TITLE
Update path to Logstash configs on SEC555 VM

### DIFF
--- a/Resources/LogStashConfigArch.md
+++ b/Resources/LogStashConfigArch.md
@@ -31,7 +31,7 @@ SEC555 LogStash Configs
 ------
 
 ### **SEC555 VM**
-> LogStash config files are stored on SEC555VM at: **`/opt/Logstash-Configs/configfiles`**
+> LogStash config files are stored on SEC555VM at: **`/labs/logstash/logstash_configs`**
 
 ### **GitHub**
 > Justin Henderson's (@SecurityMapper) LogStash Configs on GitHub:


### PR DESCRIPTION
I do believe this new path is the correct/new location that should be referenced in the wiki